### PR TITLE
Add summary endpoint integration

### DIFF
--- a/app/api/summary/[request_id]/route.js
+++ b/app/api/summary/[request_id]/route.js
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export async function GET(request, { params }) {
+  const { request_id } = params;
+  try {
+    if (!API_BASE_URL) {
+      throw new Error('NEXT_PUBLIC_API_URL environment variable is not configured');
+    }
+
+    const fullApiUrl = `${API_BASE_URL}/api/summary/${request_id}`;
+
+    const response = await fetch(fullApiUrl);
+
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json(data, {
+      status: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+    });
+  } catch (error) {
+    console.error('Error proxying request to API:', error);
+    console.error('API URL used:', `${API_BASE_URL}/api/summary/${params?.request_id}`);
+
+    return NextResponse.json(
+      { error: 'Failed to fetch summary' },
+      {
+        status: 500,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
+      }
+    );
+  }
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/app/components/assessment/AssessmentOrchestrator.tsx
+++ b/app/components/assessment/AssessmentOrchestrator.tsx
@@ -20,6 +20,7 @@ export default function AssessmentOrchestrator() {
     followUpQuestions: [],
     personalityResponses: [],
     personalityApiStatus: { loading: false, error: null, success: false },
+    requestId: null,
     generatedSummary: null,
     summaryApiStatus: { loading: false, error: null, success: false },
     startTime: new Date(),
@@ -129,9 +130,12 @@ export default function AssessmentOrchestrator() {
       }
 
       const data = await followUpResult.json();
-      
-      // Store this data in state for PersonalityQuestionsStep
-      updateAssessmentData({ followUpQuestions: data.questions || [] });
+
+      // Store this data in state for PersonalityQuestionsStep and save request ID
+      updateAssessmentData({
+        followUpQuestions: data.questions || [],
+        requestId: data.request_id || null
+      });
       
     } catch (error) {
       console.error('Error with follow-up questions API:', error);

--- a/app/components/assessment/steps/ResultsSummaryStep.tsx
+++ b/app/components/assessment/steps/ResultsSummaryStep.tsx
@@ -1,10 +1,53 @@
+import { useEffect } from 'react';
 import { StepProps } from '../types';
 
-export default function ResultsSummaryStep({ 
-  assessmentState
+export default function ResultsSummaryStep({
+  assessmentState,
+  onUpdateData
 }: StepProps) {
-  const { interests, selfDescription, groupSelection, personalityResponses } = assessmentState;
-  
+  const {
+    interests,
+    selfDescription,
+    groupSelection,
+    personalityResponses,
+    requestId,
+    generatedSummary,
+    summaryApiStatus
+  } = assessmentState;
+
+  useEffect(() => {
+    const fetchSummary = async () => {
+      if (!requestId) return;
+
+      onUpdateData({
+        summaryApiStatus: { loading: true, error: null, success: false }
+      });
+
+      try {
+        const response = await fetch(`/api/summary/${requestId}`);
+        if (!response.ok) {
+          throw new Error(`Summary API call failed: ${response.status} ${response.statusText}`);
+        }
+        const data = await response.json();
+
+        onUpdateData({
+          generatedSummary: data.summary || null,
+          summaryApiStatus: { loading: false, error: null, success: true }
+        });
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'An unknown error occurred';
+        onUpdateData({
+          summaryApiStatus: { loading: false, error: errorMessage, success: false }
+        });
+      }
+    };
+
+    if (!generatedSummary && !summaryApiStatus.loading) {
+      fetchSummary();
+    }
+  }, [requestId, generatedSummary, summaryApiStatus.loading, onUpdateData]);
+
   return (
     <div className="text-center space-y-6">
       <div className="bg-green-50 border border-green-200 rounded-lg p-6">
@@ -14,7 +57,22 @@ export default function ResultsSummaryStep({
         <p className="text-green-700 mb-4">
           Thank you for completing the personality assessment. Your responses have been recorded.
         </p>
-        
+
+        {summaryApiStatus.loading && (
+          <p className="text-sm text-gray-600 mb-4">Generating your personalized summary...</p>
+        )}
+
+        {summaryApiStatus.error && (
+          <p className="text-sm text-red-600 mb-4">Error: {summaryApiStatus.error}</p>
+        )}
+
+        {generatedSummary && (
+          <div className="bg-white rounded-lg p-4 shadow-sm text-left space-y-2 max-w-2xl mx-auto mb-4">
+            <h4 className="font-medium text-gray-800">Your Summary:</h4>
+            <p className="text-sm text-gray-600 whitespace-pre-line">{generatedSummary}</p>
+          </div>
+        )}
+
         <div className="text-left space-y-4 max-w-2xl mx-auto">
           <div className="bg-white rounded-lg p-4 shadow-sm">
             <h4 className="font-medium text-gray-800 mb-2">Summary:</h4>
@@ -26,11 +84,11 @@ export default function ResultsSummaryStep({
             </ul>
           </div>
         </div>
-        
+
         <p className="text-sm text-gray-600 mt-4">
           Your anonymous data helps advance personality research. Thank you for contributing!
         </p>
       </div>
     </div>
   );
-} 
+}

--- a/app/components/assessment/types.ts
+++ b/app/components/assessment/types.ts
@@ -45,6 +45,7 @@ export interface AssessmentState {
   followUpQuestions: FollowUpQuestion[]; // From follow-up questions API
   personalityResponses: PersonalityResponseData[];
   personalityApiStatus: ApiStatus;
+  requestId: string | null;
   
   // Phase 5: Results
   generatedSummary: string | null;


### PR DESCRIPTION
## Summary
- Add API route to proxy summary requests to backend Lambda.
- Track `requestId` from follow-up questions to retrieve summary.
- Fetch and display personalized summary on completion of assessment.

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d98b6fda88331853b150beea78750