### PR TITLE
chore: update API routes for new backend

### DIFF
--- a/app/api/followup/route.js
+++ b/app/api/followup/route.js
@@ -12,10 +12,25 @@ export async function POST(request) {
     // Get the request body
     const body = await request.json();
     
-    // Construct the full API URL
-    const fullApiUrl = `${API_BASE_URL}/api/get-groups-showcase`;
+    // Validate the interests data
+    if (!body.interests || !Array.isArray(body.interests)) {
+      return NextResponse.json(
+        { error: 'Invalid interests data' },
+        { status: 400 }
+      );
+    }
+
+    if (body.interests.length < 3) {
+      return NextResponse.json(
+        { error: 'At least 3 interests are required' },
+        { status: 400 }
+      );
+    }
     
-    // Forward the request to the API
+    // Construct the full API URL
+    const fullApiUrl = `${API_BASE_URL}/api/followup`;
+    
+    // Forward the request to the AWS Lambda API
     const response = await fetch(fullApiUrl, {
       method: 'POST',
       headers: {
@@ -40,10 +55,10 @@ export async function POST(request) {
         'Access-Control-Allow-Headers': 'Content-Type',
       },
     });
-    
+
   } catch (error) {
     console.error('Error proxying request to API:', error);
-    console.error('API URL used:', `${API_BASE_URL}/api/get-groups-showcase`);
+    console.error('API URL used:', `${API_BASE_URL}/api/followup`);
     
     return NextResponse.json(
       { error: 'Failed to process request' },

--- a/app/api/groups/route.js
+++ b/app/api/groups/route.js
@@ -12,25 +12,10 @@ export async function POST(request) {
     // Get the request body
     const body = await request.json();
     
-    // Validate the interests data
-    if (!body.interests || !Array.isArray(body.interests)) {
-      return NextResponse.json(
-        { error: 'Invalid interests data' },
-        { status: 400 }
-      );
-    }
-
-    if (body.interests.length < 3) {
-      return NextResponse.json(
-        { error: 'At least 3 interests are required' },
-        { status: 400 }
-      );
-    }
-    
     // Construct the full API URL
-    const fullApiUrl = `${API_BASE_URL}/api/follow-up-questions`;
+    const fullApiUrl = `${API_BASE_URL}/api/groups`;
     
-    // Forward the request to the AWS Lambda API
+    // Forward the request to the API
     const response = await fetch(fullApiUrl, {
       method: 'POST',
       headers: {
@@ -55,10 +40,10 @@ export async function POST(request) {
         'Access-Control-Allow-Headers': 'Content-Type',
       },
     });
-
+    
   } catch (error) {
     console.error('Error proxying request to API:', error);
-    console.error('API URL used:', `${API_BASE_URL}/api/follow-up-questions`);
+    console.error('API URL used:', `${API_BASE_URL}/api/groups`);
     
     return NextResponse.json(
       { error: 'Failed to process request' },

--- a/app/components/assessment/AssessmentOrchestrator.tsx
+++ b/app/components/assessment/AssessmentOrchestrator.tsx
@@ -117,7 +117,7 @@ export default function AssessmentOrchestrator() {
     try {
       const groupsResult = await handleApiCall(
         async () => {
-          const response = await fetch('/api/get-groups-showcase', {
+          const response = await fetch('/api/groups', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -150,7 +150,7 @@ export default function AssessmentOrchestrator() {
   // Follow-up questions API call - runs independently in background
   const handleFollowUpQuestionsApiCall = useCallback(async (requestData: InterestsApiRequest) => {
     try {
-      const followUpResult = await fetch('/api/follow-up-questions', {
+      const followUpResult = await fetch('/api/followup', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- point group request to new `/api/groups` backend route
- align follow-up question call with new `/api/followup` endpoint
- update assessment orchestrator to use updated API routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68951e895b0083319d6248077aa86312